### PR TITLE
Fix chat color and icon input parsing

### DIFF
--- a/src/main/java/dev/revivalo/playerwarps/warp/action/SetPreviewItemAction.java
+++ b/src/main/java/dev/revivalo/playerwarps/warp/action/SetPreviewItemAction.java
@@ -1,9 +1,11 @@
 package dev.revivalo.playerwarps.warp.action;
 
+import com.cryptomorin.xseries.XMaterial;
 import dev.revivalo.playerwarps.configuration.file.Config;
 import dev.revivalo.playerwarps.configuration.file.Lang;
 import dev.revivalo.playerwarps.util.PermissionUtil;
 import dev.revivalo.playerwarps.warp.Warp;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
@@ -12,6 +14,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -21,10 +25,16 @@ public class SetPreviewItemAction implements WarpAction<String> {
     public boolean execute(Player player, Warp warp, String item) {
         try {
             ItemStack displayItem;
-            if (item.equalsIgnoreCase("HAND")) {
-                displayItem = new ItemStack(player.getInventory().getItemInMainHand().getType());
+            String normalizedItem = normalizeItemName(item);
+            if (normalizedItem.equalsIgnoreCase("HAND")) {
+                displayItem = player.getInventory().getItemInMainHand().clone();
             } else {
-                displayItem = new ItemStack(Material.valueOf(item.toUpperCase()));
+                Optional<Material> material = matchMaterial(normalizedItem);
+                if (material.isEmpty()) {
+                    player.sendMessage(Lang.INVALID_ITEM.asColoredString());
+                    return false;
+                }
+                displayItem = new ItemStack(material.get());
             }
 
             ItemMeta meta = displayItem.getItemMeta();
@@ -50,12 +60,57 @@ public class SetPreviewItemAction implements WarpAction<String> {
                 warp.setMenuItem(displayItem);
                 player.sendMessage(Lang.ITEM_CHANGED.asColoredString().replace("%item%", itemName));
             }
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException | NullPointerException exception) {
             player.sendMessage(Lang.INVALID_ITEM.asColoredString());
             return false;
         }
 
         return true;
+    }
+
+    private Optional<Material> matchMaterial(String itemName) {
+        Material material = Material.matchMaterial(itemName);
+        if (material == null) {
+            material = XMaterial.matchXMaterial(itemName)
+                    .map(XMaterial::parseMaterial)
+                    .orElse(null);
+        }
+        return Optional.ofNullable(material);
+    }
+
+    private static String normalizeItemName(String item) {
+        String normalized = Objects.requireNonNull(item, "item").trim();
+
+        normalized = ChatColor.stripColor(normalized);
+        if (normalized == null) {
+            return "";
+        }
+
+        normalized = stripWrappingQuotes(normalized.trim());
+        if (normalized.toLowerCase(Locale.ENGLISH).startsWith("minecraft:")) {
+            normalized = normalized.substring("minecraft:".length());
+        }
+
+        return normalized
+                .replace(' ', '_')
+                .replace('-', '_');
+    }
+
+    private static String stripWrappingQuotes(String item) {
+        if (item.length() < 2) {
+            return item;
+        }
+
+        char first = item.charAt(0);
+        char last = item.charAt(item.length() - 1);
+
+        if ((first == '"' && last == '"') || (first == '\'' && last == '\'')
+                || (first == '`' && last == '`') || (first == '\u201c' && last == '\u201d')
+                || (first == '\u2018' && last == '\u2019')) {
+            return item.substring(1, item.length() - 1).trim();
+        }
+
+        return item;
     }
 
     @Override
@@ -83,6 +138,10 @@ public class SetPreviewItemAction implements WarpAction<String> {
         BANNED_ITEMS.add(Material.NETHER_PORTAL);
         BANNED_ITEMS.add(Material.END_PORTAL);
         BANNED_ITEMS.add(Material.AIR);
-        BANNED_ITEMS.addAll(Config.BANNED_ITEMS.asList().stream().map(Material::valueOf).collect(Collectors.toList()));
+        BANNED_ITEMS.addAll(Config.BANNED_ITEMS.asList().stream()
+                .map(SetPreviewItemAction::normalizeItemName)
+                .map(Material::matchMaterial)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
Fixes warp icon selection failing when the chat input contains formatting artifacts or player-friendly material names.

The icon setter used to pass the raw chat response directly into `Material.valueOf`, so inputs could fail if they had color codes, surrounding quotes, spaces, dashes, or a minecraft: namespace. This normalizes the input before matching it and uses `Material.matchMaterial` with the existing XSeries fallback.

Tested stuff


- Verified icon input works through the normal chat prompt with `hand` and material names.
- mvn -q -DskipTests package is currently blocked in a clean checkout because the repository references a missing system dependency at `libs/Territory-1.2.1.jar`.
